### PR TITLE
docs: suggest improvement to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,12 +1,23 @@
 SCADE Examples
 ==============
 
-This repository contains a collection of examples that demonstrate how to use
-the ANSYS SCADE tools.
+|license| |doc|
+
+.. |license| image:: https://img.shields.io/badge/License-MIT-yellow.svg
+   :target: https://opensource.org/licenses/MIT
+   :alt: MIT License
+
+.. |doc| image:: https://img.shields.io/badge/docs-scade%20examples-green.svg?style=flat
+   :target: https://examples.scade.docs.pyansys.com/
+   :alt: Doc
+
+This repository is a place to build a documentation index page for a collection of examples demonstrating how to use the Ansys SCADE tools.
+
+*Note*: this repository does not contain the examples themselves. Each example's sources can be accessed from its documentation.
 
 Documentation
 -------------
-The documentation for this repository is hosted at `examples.scade.docs.pyansys.com <https://examples.scade.docs.pyansys.com/>`_.
+The documentation for Ansys SCADE examples is hosted at `examples.scade.docs.pyansys.com <https://examples.scade.docs.pyansys.com/>`_.
 
 License
 -------

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-SCADE Examples
-==============
+SCADE Examples Documentation
+============================
 
 |license| |doc|
 


### PR DESCRIPTION
As discussed in ecosystem review, here is a wording suggestion to explicitly state that this repository does not contain any example but builds the documentation index page referencing available examples.