### PR TITLE
docs: fix typo in contribution guidelines

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -49,7 +49,7 @@ source and enhance it.
    .. code:: bash
 
       python -m pip install -U pip     # Upgrading pip
-      python -m pip install -r requierements/doc.txt     # for building the documentation
+      python -m pip install -r requirements/requirements_doc.txt     # for building the documentation
 
 Use ``pre-commit``
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Apply fix inspired by the [scadeone-examples doc review](https://github.com/ansys-internal/scadeone-examples/pull/5).